### PR TITLE
Add a representation to the class

### DIFF
--- a/folioclient/FolioClient.py
+++ b/folioclient/FolioClient.py
@@ -33,6 +33,10 @@ class FolioClient:
         }
 
     @cached_property
+    def __repr__(self) -> str:
+        return f"FolioClient for tenant {self.tenant_id} at {self.okapi_url} as {self.username}"
+
+    @cached_property
     def current_user(self):
         logging.info("fetching current user..")
         try:

--- a/folioclient/FolioClient.py
+++ b/folioclient/FolioClient.py
@@ -32,7 +32,6 @@ class FolioClient:
             "content-type": "application/json",
         }
 
-    @cached_property
     def __repr__(self) -> str:
         return f"FolioClient for tenant {self.tenant_id} at {self.okapi_url} as {self.username}"
 


### PR DESCRIPTION
This enables users to do a `print(folio_client)` and get more than a class name and a memory reference