### PR TITLE
Refactor how query parameters are handled for FolioClient.folio_get_all and FolioClient.folio_get

### DIFF
--- a/folioclient/FolioClient.py
+++ b/folioclient/FolioClient.py
@@ -200,12 +200,12 @@ class FolioClient:
 
     def _construct_query_parameters(self, **kwargs) -> Dict[str, Any]:
         """Private method to construct query parameters for folio_get or httpx client calls"""
+        query = kwargs.pop("query")
         params = kwargs
-        if query := kwargs.pop("query"):
-            if query.startswith(("?", "query=")):  # Handle previous query specification syntax
-                params["query"] = query.split("=", maxsplit=1)[1]
-            else:
-                params["query"] = query
+        if query.startswith(("?", "query=")):  # Handle previous query specification syntax
+            params["query"] = query.split("=", maxsplit=1)[1]
+        else:
+            params["query"] = query
         return params
 
     def get_all(self, path, key=None, query=""):

--- a/folioclient/FolioClient.py
+++ b/folioclient/FolioClient.py
@@ -152,6 +152,15 @@ class FolioClient:
     def modes_of_issuance(self):
         return list(self.folio_get_all("/modes-of-issuance", "issuanceModes", self.cql_all, 1000))
 
+    @cached_property
+    def authority_source_files(self):
+        """Cached property for all configured authority source files"""
+        return list(
+            self.folio_get_all(
+                "/authority-source-files", "authoritySourceFiles", self.cql_all, 1000
+            )
+        )
+
     def login(self):
         """Logs into FOLIO in order to get the okapi token"""
         payload = {"username": self.username, "password": self.password}

--- a/folioclient/FolioClient.py
+++ b/folioclient/FolioClient.py
@@ -218,8 +218,8 @@ class FolioClient:
         * path: FOLIO API endpoint path
         * key: Key in JSON response from FOLIO that includes the array of results for query APIs
         * query: For backwards-compatibility
-        * query_params: If applying a `sortBy` statement to your query, the query should be 
-                        specified last
+        * query_params: Additional query parameters for the specified path. May also be used for
+                        `query`
         """
         url = self.okapi_url + path
         if query and query_params:
@@ -367,6 +367,7 @@ class FolioClient:
         name = next(f for f in [*resp] if f != "totalRecords")
         rand = random.randint(0, total)  # noqa # NOSONAR not used in secure context
         query_params = {}
+        query_params["query"] = query or self.cql_all
         query_params["limit"] = count
         query_params["offset"] = rand
         print(f"{total} {path} found, picking {count} from {rand} onwards")

--- a/folioclient/FolioClient.py
+++ b/folioclient/FolioClient.py
@@ -181,7 +181,7 @@ class FolioClient:
             offset = 0
             query = query or " ".join((self.cql_all, "sortBy id"))
             query_params: Dict[str, Any] = self._construct_query_parameters(
-                query=query, limit=limit, offset=offset * limit, **kwargs
+                limit=limit, offset=offset * limit, query=query, **kwargs
             )
             temp_res = self.folio_get(path, key, query_params=query_params)
             yield from temp_res
@@ -189,13 +189,13 @@ class FolioClient:
                 offset += 1
                 temp_res = self.folio_get(
                     path, key, query_params=self._construct_query_parameters(
-                        query=query, limit=limit, offset=offset * limit, **kwargs
+                        limit=limit, offset=offset * limit, query=query, **kwargs
                     )
                 )
                 yield from temp_res
             offset += 1
             yield from self.folio_get(path, key, query_params=self._construct_query_parameters(
-                query=query, limit=limit, offset=offset * limit, **kwargs
+                limit=limit, offset=offset * limit, query=query, **kwargs
             ))
 
     def _construct_query_parameters(self, **kwargs) -> Dict[str, Any]:

--- a/folioclient/FolioClient.py
+++ b/folioclient/FolioClient.py
@@ -181,7 +181,7 @@ class FolioClient:
             offset = 0
             query = query or " ".join((self.cql_all, "sortBy id"))
             query_params: Dict[str, Any] = self._construct_query_parameters(
-                limit=limit, offset=offset * limit, query=query, **kwargs
+                query=query, limit=limit, offset=offset * limit, **kwargs
             )
             temp_res = self.folio_get(path, key, query_params=query_params)
             yield from temp_res
@@ -189,23 +189,23 @@ class FolioClient:
                 offset += 1
                 temp_res = self.folio_get(
                     path, key, query_params=self._construct_query_parameters(
-                        limit=limit, offset=offset * limit, query=query, **kwargs
+                        query=query, limit=limit, offset=offset * limit, **kwargs
                     )
                 )
                 yield from temp_res
             offset += 1
             yield from self.folio_get(path, key, query_params=self._construct_query_parameters(
-                limit=limit, offset=offset * limit, query=query, **kwargs
+                query=query, limit=limit, offset=offset * limit, **kwargs
             ))
 
     def _construct_query_parameters(self, **kwargs) -> Dict[str, Any]:
         """Private method to construct query parameters for folio_get or httpx client calls"""
-        query = kwargs.pop("query")
         params = kwargs
-        if query.startswith(("?", "query=")):  # Handle previous query specification syntax
-            params["query"] = query.split("=", maxsplit=1)[1]
-        else:
-            params["query"] = query
+        if query := kwargs.get("query"):
+            if query.startswith(("?", "query=")):  # Handle previous query specification syntax
+                params["query"] = query.split("=", maxsplit=1)[1]
+            else:
+                params["query"] = query
         return params
 
     def get_all(self, path, key=None, query=""):

--- a/folioclient/FolioClient.py
+++ b/folioclient/FolioClient.py
@@ -201,7 +201,7 @@ class FolioClient:
     def _construct_query_parameters(self, **kwargs) -> Dict[str, Any]:
         """Private method to construct query parameters for folio_get or httpx client calls"""
         params = kwargs
-        if query := kwargs.get("query"):
+        if query := kwargs.pop("query"):
             if query.startswith(("?", "query=")):  # Handle previous query specification syntax
                 params["query"] = query.split("=", maxsplit=1)[1]
             else:


### PR DESCRIPTION
This PR includes:

- Refactor of `folio_get_all` and `folio_get` methods of `FolioClient` to include API `query=` parameters in the `params` argument when performing requests via `httpx`
- Support both the existing `"?query=…"` query syntax as well as just the query string, itself (eg. `'cql.allRecords=1 and personal.middleName="" sortBy id'`
- Support for `sortBy` statements in queries (required to avoid skipping records with folio_get_all when records are being actively updated, fixes #12)