### PR TITLE
Fixes: get_single_instance method returns generator object instead of dictionary #63

### DIFF
--- a/folioclient/FolioClient.py
+++ b/folioclient/FolioClient.py
@@ -286,7 +286,7 @@ class FolioClient:
         self.okapi_token_duration = self.okapi_token_expires - datetime.now(tz.utc)
 
     def get_single_instance(self, instance_id):
-        return self.folio_get_all(f"inventory/instances/{instance_id}")
+        return self.folio_get_single_object(f"inventory/instances/{instance_id}")
 
     def folio_get_all(self, path, key=None, query=None, limit=10, **kwargs):
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "folioclient"
-version = "0.60.4"
+version = "0.60.5"
 authors = ["Theodor Tolstoy <github.teddes@tolstoy.se>", "Brooks Travis <brooks.travis@gmail.com>"]
 description = "An API wrapper over the FOLIO LSP API Suite OKAPI."
 repository = "https://github.com/FOLIO-FSE/folioclient"


### PR DESCRIPTION
Changed get_single_instance method to use folio_get_single_object, instead of folio_get_all 