### PR TITLE
Updates httpx to latest version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ profile = "black"
 
 [tool.poetry.dependencies]
 python = "^3.9"
-httpx = "^0.23.3"
+httpx = "^0.27.2"
 pyyaml = "^6.0"
 py-openapi-schema-to-json-schema = "^0.0.3"
 python-dateutil = "^2.8.2"


### PR DESCRIPTION
At Stanford we are using the FolioClient in our Airflow environments to manage FOLIO workflows but are currently unable to upgrade to the latest version of Airflow (2.10.1) because of FolioClient is pinned to an earlier version of httpx and Airflow requires [httpx version 0.25.0](https://github.com/apache/airflow/blob/32ec3d371baa0fb34a9260de3daec2c8c5376e55/hatch_build.py#L444) or above.