### PR TITLE
Add __enter__ and __exit__ method to enable context manager usage. Add FolioClientClosed custom exception. Bump version to 0.61.1.

### DIFF
--- a/folioclient/__init__.py
+++ b/folioclient/__init__.py
@@ -1,5 +1,7 @@
 import importlib.metadata
 
-__version__ = importlib.metadata.version("folioclient")
-
 from folioclient.FolioClient import FolioClient
+from folioclient.exceptions import FolioClientClosed
+
+__version__ = importlib.metadata.version("folioclient")
+__all__ = ["FolioClient", "FolioClientClosed"]

--- a/folioclient/exceptions.py
+++ b/folioclient/exceptions.py
@@ -1,0 +1,12 @@
+"""
+Custom exceptions for the folioclient package.
+"""
+
+
+class FolioClientClosed(Exception):
+    """
+    Raised when an operation is attempted on a closed FolioClient.
+    """
+
+    def __init__(self, message: str = "The FolioClient is closed") -> None:
+        super().__init__(message)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "folioclient"
-version = "0.61.0"
+version = "0.61.1"
 authors = ["Theodor Tolstoy <github.teddes@tolstoy.se>", "Brooks Travis <brooks.travis@gmail.com>"]
 description = "An API wrapper over the FOLIO LSP API Suite OKAPI."
 repository = "https://github.com/FOLIO-FSE/folioclient"


### PR DESCRIPTION
Closes #75